### PR TITLE
Docs/init template

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@
 
 <details>
   <summary><strong>Table of Contents</strong> (click to expand)</summary>
+
 <!-- toc -->
+
 - [✅ To-do](#--to-do)
 - [📋 Concept](#---concept)
 - [🧐 Instruction manual](#---instruction-manual)
@@ -39,6 +41,7 @@
   * [Credits](#credits)
   * [Inspiration sources](#inspiration-sources)
 - [🗺️ License](#----license)
+
 <!-- tocstop -->
 
 </details>

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [link to live demo]
 [screenshot of website]
 
-[![Deploy Status](https://api.netlify.com/api/v1/badges/9aec17a8-142c-40c1-a2b2-ad3e73f9f652/deploy-status)](https://app.netlify.com/sites/wafs/deploys)
+[deploy status]()
 
 
 <details>


### PR DESCRIPTION
## Description
Table of contents is now displayed correctly && deploy status is now a text placeholder

## Testing
Go to 'files changed', select _'display the rich diff'_ (or click [here](https://github.com/kriskuiper/cmd-digital-playground/compare/master...docs/init-template?short_path=04c6e90#diff-04c6e90faac2675aa89e2176d2eec7d8)) and read the readme. Is the TOC now displayed correctly, and the link to Netlify replaced by a text placeholder?

## To do after merging this PR (optional)
Naturally, there's still info missing about the project. It'll be updated during the development.
