### PR TITLE
added glob-importer to node-sass build command

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build": "cross-env ELEVENTY_ENV=production run-s build:*",
     "build:eleventy": "eleventy",
     "build:js": "rollup --config",
-    "build:css": "node-sass src/assets/scss/app.scss _site/styles/index.css",
+    "build:css": "node-sass --importer node_modules/node-sass-glob-importer/dist/cli.js src/assets/scss/app.scss _site/styles/index.css",
     "predev": "rimraf _site",
     "dev": "cross-env ELEVENTY_ENV=development run-p dev:*",
     "dev:eleventy": "eleventy --serve --watch --port 3031",


### PR DESCRIPTION
## Description
Added the node-sass-glob-importer in the command line in package.json.
This was a bug, now the glob is able to be parsed by SCSS in src/assets/scss/app.scss

## Testing
`npm run build:css`

## To do after merging this PR (optional)
Write awesome code in SCSS & fix the import the components SCSS with a glob.
