### PR TITLE
Feat/button component in preview

### DIFF
--- a/src/assets/js/preview-environment/components/button.js
+++ b/src/assets/js/preview-environment/components/button.js
@@ -1,0 +1,16 @@
+export default ({ _editable, text, type, link }) => {
+  if (type === 'button') {
+    return `
+    <button class="button">
+      ${text}
+    </button>
+  `
+  } else {
+    return `
+    <a class="button" href="${link.url}">
+      ${text}
+    </a>
+    `
+  }
+
+}

--- a/src/assets/js/preview-environment/utils/render-modular-content-components.js
+++ b/src/assets/js/preview-environment/utils/render-modular-content-components.js
@@ -1,9 +1,13 @@
 import testComponent from '../components/test-component'
+import button from '../components/button'
 
 export default ($modularContentElement, components) => {
   components.forEach(componentData => {
     if (componentData.component === 'Test component') {
       $modularContentElement.innerHTML += testComponent(componentData)
+    }
+    if (componentData.component === 'Button') {
+      $modularContentElement.innerHTML += button(componentData)
     }
   })
 }


### PR DESCRIPTION
## Description
Button component is now visible in Storyblok preview-mode. Imported with JS.

## Testing
Replace permalink in `src/site/page-pages.htmlz with the following: `permalink: "/pages/{{ story.slug | slug }}/"`. 
Go to online environment of Storyblok and preview pages/demo. The two styled buttons should now be shown.

## To do after merging this PR (optional)
Path of permalink is still an issue, but the above is an good workaround for now.

![red button gif](https://media.giphy.com/media/GwRBmXyEOvFtK/giphy.gif)