### PR TITLE
Fix/permalink issue

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,6 +1,10 @@
+const correctPageSlug = require('./lib/filters/correct-page-slug')
+
 module.exports = (eleventyConfig) => {
   eleventyConfig.addLayoutAlias('default', 'layouts/default.html')
   eleventyConfig.addPassthroughCopy({'src/assets/fonts': 'fonts'})
+
+  eleventyConfig.addNunjucksFilter('correctPageSlug', correctPageSlug)
 
   return {
     dir: {

--- a/lib/filters/correct-page-slug.js
+++ b/lib/filters/correct-page-slug.js
@@ -1,0 +1,5 @@
+module.exports = (page) => {
+  const env = process.env.ELEVENTY_ENV
+
+  return env === 'production' ? page.slug : page.full_slug
+}

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -7,6 +7,6 @@ layout: "default"
 <h2>Try going to another page:</h2>
 <ul>
   {% for story in site.stories %}
-  <li><a href="{{ story.slug }}">{{ story.title }}</a></li>
+  <li><a href="{{ story | correctPageSlug }}">{{ story.title }}</a></li>
   {% endfor %}
 </ul>

--- a/src/site/page-pages.html
+++ b/src/site/page-pages.html
@@ -3,7 +3,7 @@ pagination:
   data: site.stories
   size: 1
   alias: story
-permalink: "{{ story.slug | slug }}/"
+permalink: "{{ story | correctPageSlug }}/"
 eleventyComputed:
   title: "{{ story.title }}"
 layout: "default"


### PR DESCRIPTION
## Description
We have an issue where the permalink in preview does not correspond with our setup. This PR fixes it by piping the slug through a `correctPageSlug` filter. Now when we are in production the filter gives us the base slug (for example `/demo`). When in dev and preview it gives us `/pages/demo`. So the preview environment won't break.

## Testing
Preview environment should show everything as it was. So try to go to `/home` and it should serve a page. You can also try to run a development environment and open Storyblok and go to that certain page. Now the page should show up.
