### PR TITLE
Fix/permalink real path

### DIFF
--- a/.eleventy.js
+++ b/.eleventy.js
@@ -1,12 +1,10 @@
 const submitText = require('./lib/filters/submit-text')
-const correctPageSlug = require('./lib/filters/correct-page-slug')
 
 module.exports = (eleventyConfig) => {
   eleventyConfig.addLayoutAlias('default', 'layouts/default.html')
   eleventyConfig.addPassthroughCopy({'src/assets/fonts': 'fonts'})
 
   eleventyConfig.addNunjucksFilter('submitText', submitText)
-  eleventyConfig.addNunjucksFilter('correctPageSlug', correctPageSlug)
 
   return {
     dir: {

--- a/lib/filters/correct-page-slug.js
+++ b/lib/filters/correct-page-slug.js
@@ -1,5 +1,0 @@
-module.exports = (page) => {
-  const env = process.env.ELEVENTY_ENV
-
-  return env === 'production' ? page.slug : page.full_slug
-}

--- a/src/site/index.html
+++ b/src/site/index.html
@@ -7,6 +7,6 @@ layout: "default"
 <h2>Try going to another page:</h2>
 <ul>
   {% for story in site.stories %}
-  <li><a href="{{ story | correctPageSlug }}">{{ story.title }}</a></li>
+  <li><a href="{{ story.slug }}">{{ story.title }}</a></li>
   {% endfor %}
 </ul>

--- a/src/site/page-pages.html
+++ b/src/site/page-pages.html
@@ -3,7 +3,7 @@ pagination:
   data: site.stories
   size: 1
   alias: story
-permalink: "{{ story | correctPageSlug }}/"
+permalink: "{{ story.slug | slug }}/"
 eleventyComputed:
   title: "{{ story.title }}"
 layout: "default"


### PR DESCRIPTION
## Description
This morning I added a temporary fix for the permalink issue as described in #39. Then @deannabosschert found out that there's an app for that fix, ofcourse. So this PR deletes the temporary fix and the Real Path app in Storyblok fixes everything.

## Testing
Open the storyblok app and run a development environment, while everything is available at `localhost:3000/demo` for example, the preview environment now also uses that link instead of /pages/demo.
