### PR TITLE
Fetch events from Storyblok

### DIFF
--- a/src/site/_data/events.js
+++ b/src/site/_data/events.js
@@ -1,0 +1,19 @@
+const Storyblok = require('../../lib/storyblok-instance')
+
+module.exports = async () => {
+  const env = process.env.ELEVENTY_ENV
+  const version = env === 'production' ? 'published' : 'draft'
+
+  try {
+    const result = await Storyblok.get('cdn/stories', { version, starts_with: 'events' })
+    const events = result.data.stories
+
+    return events
+  } catch(error) {
+    if (process.env.ELEVENTY_ENV === 'development') {
+      console.error('Error fetching events: ', error)
+    }
+
+    return []
+  }
+}


### PR DESCRIPTION
## Description
This PR makes it possible to fetch events from Storyblok since both @gijslaarman and myself need these events to work on our tickets.

## Testing
Add `console.log(events)` to the `src/site/_data/events.js` file and you'll see that the events are fetched correctly.
