### PR TITLE
Feat/events index page

### DIFF
--- a/src/site/_data/events.js
+++ b/src/site/_data/events.js
@@ -8,7 +8,10 @@ module.exports = async () => {
     const result = await Storyblok.get('cdn/stories', { version, starts_with: 'events' })
     const events = result.data.stories
 
-    return events
+    return {
+      overviewPage: getOverviewPageData(events),
+      events: getEvents(events)
+    }
   } catch(error) {
     if (process.env.ELEVENTY_ENV === 'development') {
       console.error('Error fetching events: ', error)
@@ -16,4 +19,24 @@ module.exports = async () => {
 
     return []
   }
+}
+
+
+function getOverviewPageData(events) {
+  const overviewPageData = events.find(event => {
+    return event.full_slug === 'events/'
+  })
+
+  return overviewPageData.content
+}
+
+function getEvents(events) {
+  return events
+    .filter(event => {
+      return event.full_slug !== 'events/'
+    })
+    .map(event => {
+      return event.content
+    })
+    .reverse()
 }

--- a/src/site/events.html
+++ b/src/site/events.html
@@ -1,0 +1,5 @@
+---
+layout: "default"
+---
+
+<h1>Events page</h1>

--- a/src/site/events.html
+++ b/src/site/events.html
@@ -1,5 +1,12 @@
 ---
 layout: "default"
+eleventyComputed:
+  title: "{{ events.overviewPage.title }}"
 ---
 
-<h1>Events page</h1>
+<p>{{ events.overviewPage.intro_text }}</p>
+
+{% for event in events.events %}
+  <!-- @TODO: use an event component here -->
+  <p>{{ event.title }}</p>
+{% endfor %}


### PR DESCRIPTION
## Description
This PR creates an index page where all events are shown. Also, it cleans up the event data fetching a bit by seperating the index page from the event pages.

## Testing
The preview should now have an `/events` page (don't know if Vercel config is okay here)...