### PR TITLE
Fix/header links

### DIFF
--- a/lib/add-component-slug.js
+++ b/lib/add-component-slug.js
@@ -1,0 +1,10 @@
+const slugify = require('slugify')
+
+module.exports = (content) => {
+  return content.map(contentBlock => {
+    // Make a slug from the component name, uses slugify.
+    // Input: "Test component"
+    contentBlock.componentSlug = slugify(contentBlock.component, { lower: true }) // test-component
+    return contentBlock
+  })
+}

--- a/lib/get-navigation-data.js
+++ b/lib/get-navigation-data.js
@@ -1,0 +1,25 @@
+module.exports = (stories) => {
+  return stories.reduce((navigation, currentStory) => {
+    if (currentStory.full_slug.includes('main-menu')) {
+      return {
+        ...navigation,
+        mainMenu: getMainMenuContents(currentStory)
+      }
+    }
+
+    return navigation
+  }, {})
+}
+
+function getMainMenuContents(story) {
+  return story.content.navigation_link.map(page => {
+    return {
+      name: page.name,
+      url: correctCachedUrl(page.link.cached_url)
+    }
+  })
+}
+
+function correctCachedUrl(link) {
+  return link.includes('/') ? link : `/${link}`
+}

--- a/lib/get-navigation-data.js
+++ b/lib/get-navigation-data.js
@@ -21,5 +21,7 @@ function getMainMenuContents(story) {
 }
 
 function correctCachedUrl(link) {
+  link = link.replace('pages', '')
+
   return link.includes('/') ? link : `/${link}`
 }

--- a/lib/get-pages-data.js
+++ b/lib/get-pages-data.js
@@ -1,0 +1,14 @@
+const addComponentSlug = require('./add-component-slug')
+
+module.exports = (stories) => {
+  return stories
+    .filter(story => {
+      return story.full_slug.includes('pages')
+    })
+    .map(story => ({
+      content: addComponentSlug(story.content.content),
+      title: story.name,
+      slug: story.slug,
+      full_slug: story.full_slug
+    }))
+}

--- a/src/site/_data/site.js
+++ b/src/site/_data/site.js
@@ -1,4 +1,5 @@
-const slugify = require('slugify')
+const getPagesData = require('../../../lib/get-pages-data')
+const getNavigationData = require('../../../lib/get-navigation-data')
 const Storyblok = require('../../lib/storyblok-instance')
 
 module.exports = async () => {
@@ -14,39 +15,4 @@ module.exports = async () => {
     navigation: getNavigationData(stories),
     stories: getPagesData(stories)
   }
-}
-
-function getNavigationData(stories) {
-  return stories.reduce((navigation, currentStory) => {
-    if (currentStory.full_slug.includes('main-menu')) {
-      navigation.mainMenu = currentStory
-      console.log(navigation.mainMenu.content.navigation_link);
-
-      return navigation
-    }
-
-    return navigation
-  }, {})
-}
-
-function addComponentSlug(content) {
-  return content.map(contentBlock => {
-    // Make a slug from the component name, uses slugify.
-    // Input: "Test component"
-    contentBlock.componentSlug = slugify(contentBlock.component, { lower: true }) // test-component
-    return contentBlock
-  })
-}
-
-function getPagesData(stories) {
-  return stories
-    .filter(story => {
-    return story.full_slug.includes('pages')
-    })
-    .map(story => ({
-      content: addComponentSlug(story.content.content),
-      title: story.name,
-      slug: story.slug,
-      full_slug: story.full_slug
-    }))
 }

--- a/src/site/_includes/components/header/header.html
+++ b/src/site/_includes/components/header/header.html
@@ -4,15 +4,15 @@
 <header class="main-menu">
   <div class="main-menu__top">
     <div class="main-menu__logo">
-      <a href="/">{{appIcon('logo-nopadding.svg', 'CMD: Amsterdam')}}</a>
+      <a href="/">{{ appIcon('logo-nopadding.svg', 'CMD: Amsterdam') }}</a>
     </div>
 
-    {{ button({ type: 'button', text: 'Menu'}) }}
+    {{ button({ type: 'button', text: 'Menu' }) }}
   </div>
 
   <nav class="main-menu__nav">
-    {% for item in site.navigation.mainMenu.content.navigation_link %}
-    <a href="{{item.link.cached_url}}">{{item.name}}</a>
+    {% for item in site.navigation.mainMenu %}
+    <a href="{{ item.url }}">{{ item.name }}</a>
     {% endfor %}
   </nav>
 


### PR DESCRIPTION
## Description
As stated in #65, the `cached_url` property was formatted a bit sloppy from the CMS outwards. This PR is a fix for that, as we now prefix every URL with a `/` if it doesn't have one yet. I also cleaned the whole data cleaning pattern up a bit by modularizing everything in it and putting it in the lib folder.

## Testing
Now every link on preview should work as expected.
