### PR TITLE
Feat/event card component

### DIFF
--- a/src/assets/scss/_helpers.scss
+++ b/src/assets/scss/_helpers.scss
@@ -6,3 +6,33 @@
 	position: absolute;
 	z-index: -1;
 }
+
+.sr-only {
+  width: 0.1px;
+	height: 0.1px;
+	opacity: 0;
+	overflow: hidden;
+	position: absolute;
+	z-index: -1;
+}
+
+// https://www.voorhoede.nl/en/blog/say-no-to-image-reflow/
+.fixed-ratio {
+  display: block;
+  position: relative;
+  height: 0;
+  overflow: hidden;
+}
+
+.fixed-ratio-content {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 100%;
+  width: 100%;
+  max-width: inherit;
+}
+
+.fixed-ratio-16by9 {
+  padding-bottom: 56.25%;
+}

--- a/src/site/_data/events.js
+++ b/src/site/_data/events.js
@@ -33,12 +33,16 @@ function getOverviewPageData(events) {
 }
 
 function getEvents(events) {
+
   return events
     .filter(event => {
       return event.full_slug !== 'events/'
     })
     .map(event => {
-      return event.content
+      return {
+        ...event.content,
+        full_slug: event.full_slug
+      }
     })
     .reverse()
 }

--- a/src/site/_includes/components/event-card/event-card.html
+++ b/src/site/_includes/components/event-card/event-card.html
@@ -1,0 +1,8 @@
+{% macro eventCard(event) %}
+  <article class="event-card">
+    <div class="event-card__content">
+      <h3 class="event-card__title">{{ event.title }}</h3>
+      <a href="/{{ event.full_slug }}">See event</a>
+    </div>
+  </article>
+{% endmacro %}

--- a/src/site/_includes/components/event-card/event-card.scss
+++ b/src/site/_includes/components/event-card/event-card.scss
@@ -1,0 +1,31 @@
+$event-card-content-height: 110px;
+
+.event-card {
+  margin-top: 10px;
+
+  &__image {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    background: #eee;
+  }
+
+  &__content {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    padding: $spacing-default;
+  }
+
+  &__type {
+    position: absolute;
+    top: -10px;
+    left: $spacing-default;
+    padding: 0 10px;
+  }
+
+  &__title {
+    font-weight: $font-weight-bold;
+  }
+}

--- a/src/site/events.html
+++ b/src/site/events.html
@@ -4,9 +4,11 @@ eleventyComputed:
   title: "{{ events.overviewPage.title }}"
 ---
 
+{% from "components/event-card/event-card.html" import eventCard %}
+
 <p>{{ events.overviewPage.intro_text }}</p>
 
 {% for event in events.events %}
   <!-- @TODO: use an event component here -->
-  <p>{{ event.title }}</p>
+  {{ eventCard(event) }}
 {% endfor %}


### PR DESCRIPTION
## Description
This PR implements an event-card component with very base design. In the end I would like it if event-cards look a bit like this: https://hike.one/updates or implement the project design guide but I don't think that is necessary to implement now.

I think we'd better implement everything now and work on the design later as it is then just a matter of adding some CSS but you know things work already. Also, Mattijs said he does not care about design that much as long as we build things so there can be built upon.

## Testing
The events page now should show two published events. Those cards should have links to the detail pages.
