### PR TITLE
Fix/page slugs

### DIFF
--- a/src/site/_data/events.js
+++ b/src/site/_data/events.js
@@ -38,11 +38,10 @@ function getEvents(events) {
       return event.full_slug !== 'events/'
     })
     .map(event => {
-      console.log(event)
-
       return {
         ...event.content,
-        full_slug: event.full_slug
+        full_slug: event.full_slug,
+        slug: event.slug
       }
     })
     .reverse()

--- a/src/site/page-events.html
+++ b/src/site/page-events.html
@@ -3,7 +3,7 @@ pagination:
   data: events.events
   size: 1
   alias: event
-permalink: "events/{{ event.title | slug }}/"
+permalink: "events/{{ event.slug | slug }}/"
 eleventyComputed:
   title: "{{ event.title }}"
 layout: "default"


### PR DESCRIPTION
## Description
Everything was on the event pages. Now I used the `event.slug` to create a slug for every page. It first used the `event.title`.

## Testing
Run a build.
