### PR TITLE
Feat/meta tags

### DIFF
--- a/lib/get-pages-data.js
+++ b/lib/get-pages-data.js
@@ -9,7 +9,11 @@ module.exports = (stories) => {
       content: addComponentSlug(story.content.content),
       title: story.name,
       slug: correctHomepageSlug(story.slug),
-      full_slug: story.full_slug
+      full_slug: story.full_slug,
+      meta: {
+        title: story.content.meta_title,
+        description: story.content.meta_description
+      }
     }))
 }
 

--- a/src/site/_data/events.js
+++ b/src/site/_data/events.js
@@ -31,6 +31,10 @@ function getEvents(events) {
     .map(event => {
       return {
         ...event.content,
+        meta: {
+          title: event.content.meta_title,
+          description: event.content.meta_description
+        },
         full_slug: event.full_slug,
         slug: event.slug
       }

--- a/src/site/_includes/components/meta.html
+++ b/src/site/_includes/components/meta.html
@@ -1,3 +1,5 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="title" content="{{ metaTitle }}">
+<meta name="description" content="{{ metaDescription }}">
 <link rel="stylesheet" href="/styles/index.css">

--- a/src/site/_includes/components/meta.html
+++ b/src/site/_includes/components/meta.html
@@ -1,5 +1,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+{% if metaTitle and metaDescription %}
 <meta name="title" content="{{ metaTitle }}">
 <meta name="description" content="{{ metaDescription }}">
+{% endif %}
 <link rel="stylesheet" href="/styles/index.css">

--- a/src/site/page-events.html
+++ b/src/site/page-events.html
@@ -6,6 +6,8 @@ pagination:
 permalink: "events/{{ event.slug | slug }}/"
 eleventyComputed:
   title: "{{ event.title }}"
+  metaTitle: "{{ event.meta.title }}"
+  metaDescription: "{{ event.meta.description }}"
 layout: "default"
 ---
 

--- a/src/site/page-pages.html
+++ b/src/site/page-pages.html
@@ -6,6 +6,8 @@ pagination:
 permalink: "{{ story.slug | slug }}/"
 eleventyComputed:
   title: "{{ story.title }} | CMD Amsterdam"
+  metaTitle: "{{ story.meta.title }}"
+  metaDescription: "{{ story.meta.description }}"
 layout: "default"
 ---
 


### PR DESCRIPTION
## Description
This PR adds a meta-title and -description to every page and/or event. In Storyblok everything has a SEO tab where content editors can add a meta title and description. Those get implemented in the front-end for every page or event.

## Testing
Go to the preview link and inspect the homepages' HTML. Open up the `head`, there should be a `<meta name="description" />` and a `<meta name="title" />` tag with sufficient description and title.
