### PR TITLE
Hotfix/modular content

### DIFF
--- a/src/site/_includes/components/modular-content.html
+++ b/src/site/_includes/components/modular-content.html
@@ -6,9 +6,26 @@
     <!-- {{ item._editable }} -->
     {% endif %}
 
-    {# site.js creates a slug from the component name. #}
-    {% from "components/" + item.componentSlug + "/" + item.componentSlug + ".html" import component %}
-    {{ component(item) }}
+    {% if item.componentSlug === 'events' %}
+      {% from 'components/events/events.html' import component %}
+      {{ component(item) }}
+    {% endif %}
+
+    {% if item.componentSlug === 'hero-header' %}
+      {% from 'components/hero-header/hero-header.html' import component %}
+      {{ component(item) }}
+    {% endif %}
+
+    {% if item.componentSlug === 'form' %}
+      {% from 'components/form/form.html' import component %}
+      {{ component(item) }}
+    {% endif %}
+
+    {% if item.componentSlug === 'button' %}
+      {% from 'components/button/button.html' import component %}
+      {{ component(item) }}
+    {% endif %}
+
     {% endfor %}
   </div>
 {% endmacro %}


### PR DESCRIPTION
## Description
This PR reverts back to using if-statements in the modular content to make importing components more explicit. Also it allows us to use include instead of macro's all the time which makes it that we had to pass data around in places you wouldn't want to..

We have to come up with an ideal solution later but for now this fixes a lot of our problems.

## Testing
The website should still work as expected.

## To do after merging this PR (optional)
Find a better way to import components inside modular-content.
