### PR TITLE
fix: correct filepath

### DIFF
--- a/src/assets/scss/_fonts.scss
+++ b/src/assets/scss/_fonts.scss
@@ -3,7 +3,9 @@
   font-style: normal;
   font-weight: 400;
   font-display: swap;
-  src: local('Open Sans Regular'), local('OpenSans-Regular'), url('/fonts/OpenSans-Regular.tff') format('truetype');
+  src: local('Open Sans Regular'),
+       local('OpenSans-Regular'),
+       url('../fonts/OpenSans-Regular.ttf') format('truetype');
 }
 
 @font-face {
@@ -11,5 +13,7 @@
   font-style: normal;
   font-weight: 700;
   font-display: swap;
-  src: local('Open Sans Bold'), local('OpenSans-Bold'), url('/fonts/OpenSans-Bold.tff') format('truetype');
+  src: local('Open Sans Bold'),
+  local('OpenSans-Bold'),
+  url('../fonts/OpenSans-Bold.tff') format('truetype');
 }


### PR DESCRIPTION
## Description
Bugfix: font loading wouldn't work, console would show `Failed to decode downloaded font: https://cmd-digital-playground-git-refactor-text-styling.kriskuiper.vercel.app/fonts/OpenSans-Regular.tff`

## Testing
Open preview, check console.