### PR TITLE
Fix/event card

### DIFF
--- a/src/site/_includes/components/event-card/event-card.scss
+++ b/src/site/_includes/components/event-card/event-card.scss
@@ -14,7 +14,7 @@ $event-card-content-height: 150px;
   &__content {
     position: relative;
     display: flex;
-    height: $event-card-content-height;
+    min-height: $event-card-content-height;
     flex-direction: column;
     justify-content: space-between;
     padding: $spacing-medium;


### PR DESCRIPTION
## Description
The height on `.event-card__content` caused y-overflow. Now I set it to min-height so it is still flexible.

## Testing
Look at the event cards on mobile, some would brake in the old situation and now they don't.